### PR TITLE
 Local variable geoSeries eclipses member field

### DIFF
--- a/lib/src/models.dart
+++ b/lib/src/models.dart
@@ -218,10 +218,6 @@ class GeoJsonPolygon {
 
   /// Serialize to a geojson feature string
   String serializeFeature() {
-    final geoSeries = <GeoSerie>[];
-    for (final geoSerie in geoSeries) {
-      geoSeries.add(geoSerie);
-    }
     return _buildGeoJsonFeature(geoSeries, "Polygon", name);
   }
 }


### PR DESCRIPTION
Am I stupid or GeoJsonPolygon.serializeFeature is broken? Local variable geoSeries eclipses member field geoSeries in that method resulting in _buildGeoJsonFeature been always fed an empty list.
That entire loop seems to be just out of place.