### PR TITLE
Serialization format mismatch

### DIFF
--- a/lib/src/models.dart
+++ b/lib/src/models.dart
@@ -293,11 +293,11 @@ String _buildGeoJsonFeature(
     coordsList.add(geoSerie.toGeoJsonCoordinatesString());
   }
   final coords = '[' + coordsList.join(",") + ']';
-  return '[{"type":"Feature","properties":{"name":"$name"}, '
+  return '{"type":"Feature","properties":{"name":"$name"}, '
           '"geometry":{"type":"$type",'
           '"coordinates":' +
       coords +
-      '}}]';
+      '}}';
 }
 
 String _buildMultiGeoJsonFeature(List<GeoJsonPolygon> polygons, String name) {


### PR DESCRIPTION
Compare this two JSON's. The former is what I feed to `geojson.parse` and the latter is what I receive from `GeoJsonFeatureCollection.serialize` when I reconstruct the polygon to send back to the web.
```
{
  "id": 18,
  "name": "map-project-good.geojson",
  "data": {
    "type": "FeatureCollection",
    "features": [
      {
...
      }
    ]
  }
}
```
```
{
  "id": 23,
  "name": "Project 1.geojson",
  "data": {
    "name": "null",
    "type": "FeatureCollection",
    "features": [
      [
        {
...
        }
      ]
    ]
  }
}
```