### PR TITLE
Include feature properties when serializing

### DIFF
--- a/lib/src/models.dart
+++ b/lib/src/models.dart
@@ -1,4 +1,5 @@
 import 'package:geopoint/geopoint.dart';
+import 'dart:convert';
 
 /// Geojson feature types
 enum GeoJsonFeatureType {
@@ -44,6 +45,8 @@ class GeoJsonFeatureCollection {
       ..write('"features": [');
     for (final feat in collection) {
       buffer.write(feat.serialize());
+      if (feat != collection.last)
+        buffer.write(',');
     }
     buffer.write("]}");
     return buffer.toString();
@@ -293,7 +296,7 @@ String _buildGeoJsonFeature(
     coordsList.add(geoSerie.toGeoJsonCoordinatesString());
   }
   final coords = '[' + coordsList.join(",") + ']';
-  return '{"type":"Feature","properties":${properties.toString()},'
+  return '{"type":"Feature","properties":${jsonEncode(properties)},'
           '"geometry":{"type":"$type",'
           '"coordinates":' +
       coords +

--- a/lib/src/models.dart
+++ b/lib/src/models.dart
@@ -83,11 +83,11 @@ class GeoJsonFeature<T> {
         break;
       case GeoJsonFeatureType.multiline:
         final geom = geometry as GeoJsonMultiLine;
-        featStr = geom.serializeFeature();
+        featStr = geom.serializeFeature(properties);
         break;
       case GeoJsonFeatureType.polygon:
         final geom = geometry as GeoJsonPolygon;
-        featStr = geom.serializeFeature();
+        featStr = geom.serializeFeature(properties);
         break;
       case GeoJsonFeatureType.multipolygon:
         final geom = geometry as GeoJsonMultiPolygon;
@@ -195,12 +195,12 @@ class GeoJsonMultiLine {
   String name;
 
   /// Serialize to a geojson feature string
-  String serializeFeature() {
+  String serializeFeature(Map properties) {
     final geoSeries = <GeoSerie>[];
     for (final line in lines) {
       geoSeries.add(line.geoSerie);
     }
-    return _buildGeoJsonFeature(geoSeries, "Line", name);
+    return _buildGeoJsonFeature(geoSeries, "Line", properties?? {"name":name});
   }
 }
 
@@ -218,8 +218,8 @@ class GeoJsonPolygon {
   String name;
 
   /// Serialize to a geojson feature string
-  String serializeFeature() {
-    return _buildGeoJsonFeature(geoSeries, "Polygon", name);
+  String serializeFeature(Map properties) {
+    return _buildGeoJsonFeature(geoSeries, "Polygon", properties??{"name":name});
   }
 }
 
@@ -287,13 +287,13 @@ class GeoJsonQuery {
 }
 
 String _buildGeoJsonFeature(
-    List<GeoSerie> geoSeries, String type, String name) {
+    List<GeoSerie> geoSeries, String type, Map properties) {
   final coordsList = <String>[];
   for (final geoSerie in geoSeries) {
     coordsList.add(geoSerie.toGeoJsonCoordinatesString());
   }
   final coords = '[' + coordsList.join(",") + ']';
-  return '{"type":"Feature","properties":{"name":"$name"}, '
+  return '{"type":"Feature","properties":${properties.toString()},'
           '"geometry":{"type":"$type",'
           '"coordinates":' +
       coords +


### PR DESCRIPTION
`GeoJsonFeature` has field `properties` but it's never used when serializing